### PR TITLE
disable teleport when all weapons collected

### DIFF
--- a/src/Components/Board.scss
+++ b/src/Components/Board.scss
@@ -44,13 +44,6 @@
   &.stolen, &.escaped {
     filter: brightness(0.2);
     border: none;
-    // background-color: grey;
-    // height: 100%;
-    // width: 100%;
-    // position:absolute;
-    // background-color:#000;
-    // border-radius: 5%;
-    // opacity:0.5;
   }
 }
 
@@ -99,6 +92,7 @@
 
 .space {
   box-sizing: border-box;
+  position: relative;
 
   &.active {
     z-index: 1;
@@ -125,7 +119,6 @@
       width: 70%;
       height: 70%;
       border-radius: 50%;
-      // position: relative;
       box-sizing: border-box;
       transition : border 600ms ease-in-out;
 
@@ -145,6 +138,21 @@
         background-color: rgba(50,205,50,0.2);
       }
     }
+  }
+
+  &.disabled-teleporter::after {
+    width: 80%;
+    height: 80%;
+    content: "";
+    position: absolute;
+    background-color: black;
+    opacity: 0.2;
+    z-index: 2;
+    border-radius: 50%;
+    top: 50%;
+    left: 50%;
+    margin-left: -18.5px;
+    margin-top: -18.5px;
   }
 }
 

--- a/src/Components/Pieces/Pawn.tsx
+++ b/src/Components/Pieces/Pawn.tsx
@@ -27,9 +27,11 @@ const Pawn = ({pawnData}: pawnProps) => {
     const docSnap = await getDoc(gameState.roomId);
     if (!docSnap.exists()) return;
     const roomFound: Room = docSnap.data() as Room;
-    const { pawns } = roomFound;
+    const { pawns, weaponsStolen } = roomFound;
 
-    await showMovableSpaces(gameState.roomId, pawns, player, pawnData, tiles)
+    const disableTeleport = weaponsStolen.length === 4;
+
+    await showMovableSpaces(gameState.roomId, pawns, player, pawnData, tiles, disableTeleport)
   }
 
   return (

--- a/src/Components/Space.tsx
+++ b/src/Components/Space.tsx
@@ -41,6 +41,7 @@ interface SpaceProps {
   colorSelected: heroColor | null,
   gridPosition: number[],
   highlightTeleporter: heroColor | null,
+  disableTeleporter: boolean,
   highlightEscalator: Escalator[],
   tileIndex: number,
 }
@@ -62,6 +63,7 @@ const Space = memo(({
   colorSelected,
   gridPosition,
   highlightTeleporter,
+  disableTeleporter,
   highlightEscalator,
   tileIndex
 }: SpaceProps) => {
@@ -82,7 +84,6 @@ const Space = memo(({
   //   tileIndex
   // });
   const { gameState } = useGame();
-
   const isTeleporter = spaceType === "teleporter";
   const teleporterColor = isTeleporter ? spaceColor : "";
 
@@ -102,6 +103,10 @@ const Space = memo(({
   useEffect(() => {
     (async () => {
       if (!isTeleporter) return;
+      if (disableTeleporter) {
+        setShowEscalator(false);
+        return;
+      }
       if (highlightTeleporter === teleporterColor) {
         let isOccupied = false;
         const docSnap = await getDoc(gameState.roomId);
@@ -121,7 +126,7 @@ const Space = memo(({
         setShowTeleport(false)
       }
     })()
-  }, [highlightTeleporter, colorSelected])
+  }, [highlightTeleporter, colorSelected, disableTeleporter])
 
 
   useEffect(() => {
@@ -223,11 +228,11 @@ const Space = memo(({
 
   return (
     <div 
-      className={`space${showMovableArea ? " active" : ""}${showTeleport ? " teleporter" : ""}${showEscalator ? " escalator" : ""}`}
+      className={`space${showMovableArea ? " active" : ""}${showTeleport ? " teleporter" : ""}${showEscalator ? " escalator" : ""}${disableTeleporter ? " disabled-teleporter" : ""}`}
       onClick={showMovableArea || showTeleport || showEscalator ? movePawn : () => {}}
        // TODO: disable if game paused
     >
-      <div className={`${teleporterColor}${showTeleport ? ' circle-multiple' : ''}`}>
+      <div className={`${teleporterColor}${showTeleport? ' circle-multiple' : ''}`}>
         {
           showTeleport ?
             <>

--- a/src/Components/Tile.tsx
+++ b/src/Components/Tile.tsx
@@ -5,9 +5,10 @@ import { tileWallSize } from '../constants';
 import isEqual from 'lodash/isEqual';
 import { 
   usePlayerDocState,
-  usePlayerHeldPawnDocState 
+  usePlayerHeldPawnDocState,
+  useWeaponsStolenDocState,
 } from '../Contexts/FirestoreContext';
-import { getDisplacementValue, tileHasBlockedSpace, shouldHighlightSpace } from '../Helpers/TileMethods';
+import { getDisplacementValue, shouldHighlightSpace } from '../Helpers/TileMethods';
 
 interface tileProps {
   tileData: DBTile,
@@ -22,6 +23,7 @@ const areEqual = (prevProps: tileProps, nextProps: tileProps) => {
 const Tile = ({tileIndex, tileData}: tileProps) => {
   const { player } = usePlayerDocState();
   const playerHeldPawn = usePlayerHeldPawnDocState()
+  const weaponsStolen = useWeaponsStolenDocState();
   
   return (
     <>
@@ -45,7 +47,11 @@ const Tile = ({tileIndex, tileData}: tileProps) => {
                   const highlightSpace = shouldHighlightSpace(playerHeldPawn, player, tileData, colIndex, rowIndex);
                   const {type, details} = space;
                   const playerHeldPawnColor = playerHeldPawn?.color;
-                  const highlightTeleporter = type === 'teleporter' && (details as TeleporterSpace).color === playerHeldPawnColor;
+                  const disableTeleporter = weaponsStolen.length === 4
+                  const highlightTeleporter = 
+                    type === 'teleporter' && 
+                    !disableTeleporter &&
+                    (details as TeleporterSpace).color === playerHeldPawnColor;
                   const highlightEscalator = details?.hasEscalator && playerHeldPawn?.showEscalatorSpaces.length;
                   
                   return (
@@ -66,6 +72,7 @@ const Tile = ({tileIndex, tileData}: tileProps) => {
                       tileIndex={tileIndex}
                       showMovableArea={highlightSpace} 
                       colorSelected={(highlightSpace || highlightTeleporter || highlightEscalator) && playerHeldPawn ? playerHeldPawn.color : null}
+                      disableTeleporter={type === 'teleporter' && disableTeleporter}
                       highlightTeleporter={highlightTeleporter ? playerHeldPawn.showTeleportSpaces: null}
                       highlightEscalator={highlightEscalator ? playerHeldPawn.showEscalatorSpaces: []}
                     />

--- a/src/Helpers/TileMethods.tsx
+++ b/src/Helpers/TileMethods.tsx
@@ -25,7 +25,8 @@ export const showMovableSpaces = async (
   pawns: DBPawns,
   player: DBPlayer,
   pawnData: DBHeroPawn,
-  tiles: DBTile[]
+  tiles: DBTile[],
+  disableTeleport: boolean
 ) => {
     const { color } = pawnData;
     const newPawns = {...pawns}
@@ -40,7 +41,9 @@ export const showMovableSpaces = async (
         pawn.blockedPositions = playerPawnActions.blockedPositions
         pawn.showMovableDirections = playerPawnActions.showMovableDirections
         pawn.showEscalatorSpaces = playerPawnActions.showEscalatorSpaces
-        pawn.showTeleportSpaces = playerPawnActions.showTeleportSpaces
+        if (!disableTeleport) {
+          pawn.showTeleportSpaces = playerPawnActions.showTeleportSpaces
+        }
       } 
       else if (pawn.playerHeld === player.number) {
         pawn.playerHeld = null;

--- a/src/utils/useFirestore.tsx
+++ b/src/utils/useFirestore.tsx
@@ -45,6 +45,9 @@ const downloadAsset = (file: string) => {
 }
 
 export const downloadAssets = async () => {
+  const test = await downloadAsset(`${svgAssets[0]}.svg`);
+  console.log('test url', test)
+
   // const svgUrls = svgAssets.map(async (asset) => await downloadAsset(`${asset}.svg`))
   // const pngUrls = pngAssets.map(async (asset) => await downloadAsset(`${asset}.png`))
   // const jpgUrls = jpgAssets.map(async (asset) => await downloadAsset(`${asset}.jpg`))


### PR DESCRIPTION
Check that all weapons collected
- disable space from highlighting teleport spaces or click to teleport spaces
- fade out opacity for teleporter spaces