### PR TITLE
fix reassignment of player numbers in lobby

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,23 +1,7 @@
 {
   "short_name": "React App",
   "name": "Create React App Sample",
-  "icons": [
-    {
-      "src": "favicon.ico",
-      "sizes": "64x64 32x32 24x24 16x16",
-      "type": "image/x-icon"
-    },
-    {
-      "src": "logo192.png",
-      "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "logo512.png",
-      "type": "image/png",
-      "sizes": "512x512"
-    }
-  ],
+  "icons": [],
   "start_url": ".",
   "display": "standalone",
   "theme_color": "#000000",

--- a/src/Components/Board.tsx
+++ b/src/Components/Board.tsx
@@ -10,10 +10,6 @@ import useHighlightArea from '../utils/useHighlightArea';
 import Timer from './Timer';
 import Pinged from './Pinged';
 import { useGameStartedDocState } from '../Contexts/FirestoreContext';
-import { usePlayerState } from '../Contexts/PlayerContext';
-import { usePlayerDocState } from '../Contexts/FirestoreContext';
-import { getDoc } from '../utils/useFirestore';
-import { Room } from '../types';
 import Objectives from './Objectives';
 import GameOver from './GameOver';
 
@@ -23,21 +19,6 @@ const BoardComponent = ({timer, pinged, children}: {timer: ReactNode, pinged: Re
   const { gameState } = useGame();
   const gameStarted = useGameStartedDocState();
   const [availableArea, highlightNewTileArea, clearHighlightAreas] = useHighlightArea(gameState.roomId);
-
-  const { players, player: currentPlayer, setPlayer } = usePlayerDocState()
-  // const playerState = usePlayerState();
-
-  // TODO revist, might need to refactor out
-  useEffect(() => {
-    (async () => {
-      if (!gameStarted) return;
-
-      // setPlayers(roomFound.players); // NEED TO Fix
-      const newCurrentPlayer = players.find((player) => player.id === currentPlayer.id);
-      if (!newCurrentPlayer) return;
-      setPlayer(newCurrentPlayer);
-    })()
-  }, [gameStarted])
 
   return (
     <>

--- a/src/Components/Board.tsx
+++ b/src/Components/Board.tsx
@@ -24,7 +24,7 @@ const BoardComponent = ({timer, pinged, children}: {timer: ReactNode, pinged: Re
   const gameStarted = useGameStartedDocState();
   const [availableArea, highlightNewTileArea, clearHighlightAreas] = useHighlightArea(gameState.roomId);
 
-  const { players, setPlayers, player: currentPlayer, setPlayer } = usePlayerDocState()
+  const { players, player: currentPlayer, setPlayer } = usePlayerDocState()
   // const playerState = usePlayerState();
 
   // TODO revist, might need to refactor out
@@ -32,12 +32,8 @@ const BoardComponent = ({timer, pinged, children}: {timer: ReactNode, pinged: Re
     (async () => {
       if (!gameStarted) return;
 
-      const docSnap = await getDoc(gameState.roomId);
-      if (!docSnap.exists()) return;
-      const roomFound = docSnap.data() as Room;
-
-      setPlayers(roomFound.players);
-      const newCurrentPlayer = roomFound.players.find((player) => player.id === currentPlayer.id);
+      // setPlayers(roomFound.players); // NEED TO Fix
+      const newCurrentPlayer = players.find((player) => player.id === currentPlayer.id);
       if (!newCurrentPlayer) return;
       setPlayer(newCurrentPlayer);
     })()

--- a/src/Components/Board.tsx
+++ b/src/Components/Board.tsx
@@ -24,9 +24,10 @@ const BoardComponent = ({timer, pinged, children}: {timer: ReactNode, pinged: Re
   const gameStarted = useGameStartedDocState();
   const [availableArea, highlightNewTileArea, clearHighlightAreas] = useHighlightArea(gameState.roomId);
 
-  const playerState = usePlayerState();
-  const {setPlayer, setPlayers} = usePlayerDocState();
+  const { players, setPlayers, player: currentPlayer, setPlayer } = usePlayerDocState()
+  // const playerState = usePlayerState();
 
+  // TODO revist, might need to refactor out
   useEffect(() => {
     (async () => {
       if (!gameStarted) return;
@@ -36,9 +37,9 @@ const BoardComponent = ({timer, pinged, children}: {timer: ReactNode, pinged: Re
       const roomFound = docSnap.data() as Room;
 
       setPlayers(roomFound.players);
-      const currentPlayer = roomFound.players.find((player) => player.number === playerState.number);
-      if (!currentPlayer) return;
-      setPlayer(currentPlayer);
+      const newCurrentPlayer = roomFound.players.find((player) => player.id === currentPlayer.id);
+      if (!newCurrentPlayer) return;
+      setPlayer(newCurrentPlayer);
     })()
   }, [gameStarted])
 

--- a/src/Components/GameOver.tsx
+++ b/src/Components/GameOver.tsx
@@ -34,7 +34,7 @@ const style = {
 
 const GameOver = () => {
   const playerDispatch = usePlayerDispatch();
-  const {setPlayer, setPlayers} = usePlayerDocState();
+  const {setPlayer} = usePlayerDocState();
   const {gameDispatch} = useGame();
   const gameOver = useGameOverDocState();
   const gameWon = useGameWonDocState();
@@ -48,7 +48,7 @@ const GameOver = () => {
     playerDispatch({type: 'setPlayer', value: {} as Player});
     gameDispatch({type: "exitRoom"});
     setPlayer({} as DBPlayer);
-    setPlayers([]);
+    // setPlayers([]); // FIX
   }
 
   return (

--- a/src/Components/GameOver.tsx
+++ b/src/Components/GameOver.tsx
@@ -34,7 +34,6 @@ const style = {
 
 const GameOver = () => {
   const playerDispatch = usePlayerDispatch();
-  const {setPlayer} = usePlayerDocState();
   const {gameDispatch} = useGame();
   const gameOver = useGameOverDocState();
   const gameWon = useGameWonDocState();
@@ -45,10 +44,9 @@ const GameOver = () => {
   }, [gameOver, gameWon])
 
   const handleClick = async () => {
-    playerDispatch({type: 'setPlayer', value: {} as Player});
+    playerDispatch({type: 'setPlayer', value: null});
     gameDispatch({type: "exitRoom"});
-    setPlayer({} as DBPlayer);
-    // setPlayers([]); // FIX
+    // delete doc or reset doc
   }
 
   return (

--- a/src/Components/Lobby.tsx
+++ b/src/Components/Lobby.tsx
@@ -40,12 +40,12 @@ const Lobby = () => {
     // save Room Code
     gameDispatch({type: "joinRoom", value: newGameCode});
     // create new player
-    const {player, dbPlayer}: PlayerFactoryType = PlayerFactory(playerName, [])
+    const {player, dbPlayer}: PlayerFactoryType = PlayerFactory(playerName, 0)
 
     console.log("dbPlayer", dbPlayer);
     console.log("player", player.number)
     setPlayer(dbPlayer)
-    playerDispatch({type: "setPlayer", value: player});
+    playerDispatch({type: "setPlayer", value: player}); // TODO most likely needs id / or same change
 
     await setDoc(newGameCode, {
       ...roomDefaultValues,
@@ -77,15 +77,15 @@ const Lobby = () => {
     // if found
     if (roomFound && !roomFound.gameStarted && roomFound.players.length <= 8) {
       // add player Number
-      const currentPlayers = roomFound.players.map(player => player.number);
+      const playerInLobby = roomFound.players.length
 
-      const {player, dbPlayer}: PlayerFactoryType = PlayerFactory(playerName, currentPlayers);
+      const {player, dbPlayer}: PlayerFactoryType = PlayerFactory(playerName, playerInLobby);
       const playersInRoom = [
         ...roomFound.players, 
         dbPlayer
       ];
       gameDispatch({type: "joinRoom", value: existingRoomCode});
-      playerDispatch({type: "setPlayer", value: player});
+      playerDispatch({type: "setPlayer", value: player});  // TODO most likely needs id / or same change
       await setDoc(existingRoomCode, 
         {
           ...roomFound,

--- a/src/Components/Lobby.tsx
+++ b/src/Components/Lobby.tsx
@@ -41,7 +41,7 @@ const Lobby = () => {
     // save Room Code
     gameDispatch({type: "joinRoom", value: newGameCode});
     // create new player
-    const {player, dbPlayer}: PlayerFactoryType = PlayerFactory(playerName, 0)
+    const {player, dbPlayer}: PlayerFactoryType = PlayerFactory(playerName, [])
 
     console.log("dbPlayer", dbPlayer);
     console.log("player", player.number)
@@ -80,8 +80,9 @@ const Lobby = () => {
     // if found
     if (roomFound && !roomFound.gameStarted && roomFound.players.length <= 8) {
       // add player Number
-      let newPlayerNo = Math.max(...roomFound.players.map( obj => obj.number));
-      const {player, dbPlayer}: PlayerFactoryType = PlayerFactory(playerName, newPlayerNo);
+      const currentPlayers = roomFound.players.map(player => player.number);
+
+      const {player, dbPlayer}: PlayerFactoryType = PlayerFactory(playerName, currentPlayers);
       const playersInRoom = [
         ...roomFound.players, 
         dbPlayer

--- a/src/Components/Lobby.tsx
+++ b/src/Components/Lobby.tsx
@@ -20,7 +20,7 @@ const Lobby = () => {
   const [existingRoomCode, setExistingRoomCode] = useState("");
   const [failJoinRoomMessage, setFailJoinRoomMessage] = useState<string>("");
   const [currentPlayer, setCurrentPlayer] = useState({})
-  const { players, setPlayers, player, setPlayer } = usePlayerDocState()
+  const { players, player, setPlayer } = usePlayerDocState()
 
   const _handleRoomCode = (e: ChangeEvent<HTMLInputElement>) => {
     setExistingRoomCode(e.target.value)
@@ -43,8 +43,8 @@ const Lobby = () => {
     const {player, dbPlayer}: PlayerFactoryType = PlayerFactory(playerName, 0)
 
     console.log("dbPlayer", dbPlayer);
-    console.log("player", player.number)
-    setPlayer(dbPlayer)
+    console.log("player", player.id)
+    // setPlayer(dbPlayer)
     playerDispatch({type: "setPlayer", value: player}); // TODO most likely needs id / or same change
 
     await setDoc(newGameCode, {
@@ -80,6 +80,8 @@ const Lobby = () => {
       const playerInLobby = roomFound.players.length
 
       const {player, dbPlayer}: PlayerFactoryType = PlayerFactory(playerName, playerInLobby);
+
+      console.log('joining room', {player, dbPlayer})
       const playersInRoom = [
         ...roomFound.players, 
         dbPlayer
@@ -93,8 +95,7 @@ const Lobby = () => {
         },
       )
       console.log("setting current player in join room", dbPlayer)
-      setPlayer(dbPlayer)
-
+      // setPlayer(dbPlayer)
     }
     else if (!roomFound) {
       setFailJoinRoomMessage("Room code not found");

--- a/src/Components/Lobby.tsx
+++ b/src/Components/Lobby.tsx
@@ -61,7 +61,7 @@ const Lobby = () => {
     const roomFound = docSnap.data() as Room;
 
     // if found
-    if (roomFound && !roomFound.gameStarted && roomFound.players.length <= 8) {
+    if (roomFound && !roomFound.gameStarted && roomFound.players.length < 8) {
       // get current number of players in Lobby
       const playersCount = roomFound.players.length
 
@@ -89,7 +89,7 @@ const Lobby = () => {
     else if (roomFound.gameStarted) {
       setFailJoinRoomMessage("Game has already started");
     }
-    else if (roomFound.players.length > 8) {
+    else if (roomFound.players.length >= 8) {
       setFailJoinRoomMessage("Game Lobby full");
     }
   }

--- a/src/Components/Pieces/Pawn.tsx
+++ b/src/Components/Pieces/Pawn.tsx
@@ -20,7 +20,7 @@ const Pawn = ({pawnData}: pawnProps) => {
   const { gameState } = useGame();
   const gamePaused = useGamePausedDocState();
 
-  const { player } = usePlayerDocState();
+  const { currentPlayer } = usePlayerDocState();
   const tiles: DBTile[] = useTilesDocState();
 
   const toggleMovableSpaces = async () => {
@@ -31,7 +31,7 @@ const Pawn = ({pawnData}: pawnProps) => {
 
     const disableTeleport = weaponsStolen.length === 4;
 
-    await showMovableSpaces(gameState.roomId, pawns, player, pawnData, tiles, disableTeleport)
+    await showMovableSpaces(gameState.roomId, pawns, currentPlayer, pawnData, tiles, disableTeleport)
   }
 
   return (
@@ -67,7 +67,7 @@ const Pawn = ({pawnData}: pawnProps) => {
               style={{
                 border: 
                   `${pawnData?.playerHeld ? 
-                    (pawnData?.playerHeld === player.number ?
+                    (pawnData?.playerHeld === currentPlayer.number ?
                       "2px solid blue"
                         : 
                       "2px solid grey")

--- a/src/Components/Pieces/Pawns.tsx
+++ b/src/Components/Pieces/Pawns.tsx
@@ -15,7 +15,7 @@ import Pawn from './Pawn';
 
 const Pawns = () => {
   const { gameState } = useGame();
-  const { player } = usePlayerDocState();
+  const { currentPlayer } = usePlayerDocState();
   const tiles: DBTile[] = useTilesDocState();
 
   useEffect(() => {
@@ -29,8 +29,8 @@ const Pawns = () => {
       const newPawns = roomFound.pawns;
 
       Object.values(newPawns).forEach((pawn: DBHeroPawn) => {
-        const playerPawnActions = getPlayerPawnActions(player, tiles, newPawns, pawn);
-        if (pawn.playerHeld === player.number) {
+        const playerPawnActions = getPlayerPawnActions(currentPlayer, tiles, newPawns, pawn);
+        if (pawn.playerHeld === currentPlayer.number) {
           pawn.blockedPositions = playerPawnActions.blockedPositions
           pawn.showMovableDirections = playerPawnActions.showMovableDirections
           pawn.showEscalatorSpaces = playerPawnActions.showEscalatorSpaces

--- a/src/Components/Pinged.tsx
+++ b/src/Components/Pinged.tsx
@@ -23,7 +23,7 @@ const playAlert = () => {
 const Pinged = () => {
   const { gameState } = useGame();
   const gamePaused = useGamePausedDocState();
-  const { player, players } = usePlayerDocState();
+  const { currentPlayer, players } = usePlayerDocState();
   const pinged = usePingedDocState();
 
   useEffect(() => {
@@ -40,7 +40,7 @@ const Pinged = () => {
         await setDoc(
           gameState.roomId, 
           {
-            pings: room.pings.filter(ping => ping !== player.number)
+            pings: room.pings.filter(ping => ping !== currentPlayer.number)
           },
         )
       }, 6000);
@@ -112,7 +112,7 @@ const Pinged = () => {
                   <List dense={true}>
                     {
                       players.map((dbPlayer) => {
-                        if (dbPlayer.number !== player.number) {
+                        if (dbPlayer.number !== currentPlayer.number) {
                           return (
                             <ListItemButton onClick={() => {
                                 popupState.close()

--- a/src/Components/PlayerArea.tsx
+++ b/src/Components/PlayerArea.tsx
@@ -15,16 +15,16 @@ const areEqual = (prevProps: PlayerAreaProps, nextProps: PlayerAreaProps) => {
 
 const PlayerArea = ({highlightNewTileArea, children} : PlayerAreaProps) => {
   const { gameState } = useGame();
-  const { player } = usePlayerDocState();
+  const { currentPlayer } = usePlayerDocState();
   const gamePaused = useGamePausedDocState();
 
   return (
     <div className="player-area">
       {
-        player.number &&
+        currentPlayer.number &&
         <>
           {
-            player.playerDirections.map(direction => {
+            currentPlayer.playerDirections.map(direction => {
               return (
                 <img 
                   key={direction}
@@ -40,7 +40,7 @@ const PlayerArea = ({highlightNewTileArea, children} : PlayerAreaProps) => {
             })
           }
           {
-            player.playerAbilities.map(ability => {
+            currentPlayer.playerAbilities.map(ability => {
               if (ability === "explore") {
                 // DECISION: use button, or image?
                 // return <button key={ability} onClick={() => highlightNewTileArea()}>Add Tile</button>

--- a/src/Components/Space.tsx
+++ b/src/Components/Space.tsx
@@ -183,7 +183,6 @@ const Space = memo(({
         newRoomValue.pawns[colorSelected].showEscalatorSpaces = [];
         newRoomValue.pawns[colorSelected].showMovableDirections = [];
         newRoomValue.pawns[colorSelected].showTeleportSpaces = null;
-        newRoomValue.pawns[colorSelected].playerHeld = null;
         newRoomValue.pawns[colorSelected].blockedPositions = {
           up: {position: null, gridPosition: null},
           down: {position: null, gridPosition: null},

--- a/src/Components/Test.tsx
+++ b/src/Components/Test.tsx
@@ -13,7 +13,7 @@ const Test = () => {
       await downloadAssets();
     })()
   }, [])
-  // const { player } = usePlayerDocState();
+  // const { currentPlayer } = usePlayerDocState();
   
   // const pawnState = usePawn(); // 2x extra re render
   

--- a/src/Components/Tile.tsx
+++ b/src/Components/Tile.tsx
@@ -21,7 +21,7 @@ const areEqual = (prevProps: tileProps, nextProps: tileProps) => {
 
 // memo could be good
 const Tile = ({tileIndex, tileData}: tileProps) => {
-  const { player } = usePlayerDocState();
+  const { currentPlayer } = usePlayerDocState();
   const playerHeldPawn = usePlayerHeldPawnDocState()
   const weaponsStolen = useWeaponsStolenDocState();
   
@@ -44,7 +44,7 @@ const Tile = ({tileIndex, tileData}: tileProps) => {
             return (
               <div className="row" key={`row${rowIndex}`}>
                 {row.map((space, colIndex) => {
-                  const highlightSpace = shouldHighlightSpace(playerHeldPawn, player, tileData, colIndex, rowIndex);
+                  const highlightSpace = shouldHighlightSpace(playerHeldPawn, currentPlayer, tileData, colIndex, rowIndex);
                   const {type, details} = space;
                   const playerHeldPawnColor = playerHeldPawn?.color;
                   const disableTeleporter = weaponsStolen.length === 4

--- a/src/Components/WaitingRoom.tsx
+++ b/src/Components/WaitingRoom.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useGame, assignRandomActions } from '../Contexts/GameContext';
 import { pawnDBInitialState } from '../Contexts/PawnContext';
 import { Paper, Stack, Button, List, ListItem, Alert, Box, Modal, Typography } from '@mui/material';
-import { DBPlayer, playerNumber } from '../types';
+import { DBPlayer, playerNumber, Player } from '../types';
 import { setDoc, useDocData } from "../utils/useFirestore"; 
 import { allTiles } from '../Data/all-tiles-data';
 import { doc } from '../utils/useFirestore'
@@ -74,17 +74,10 @@ const WaitingRoom = () => {
       
       console.log('updatedPlayers', updatedPlayers)
       // changing host number
-      if (currentPlayer.number === host) {
-        await setDoc(gameState.roomId, {
-          host: updatedPlayers[0].number,
-          players: updatedPlayers
-        })
-      } else {
-        await setDoc(gameState.roomId, {
-          players: updatedPlayers
-        })
-      }
-      playerDispatch({type: "setPlayer", value: undefined});  // TODO most likely needs id / or same change
+      await setDoc(gameState.roomId, {
+        players: updatedPlayers
+      })
+      playerDispatch({type: "setPlayer", value: null});  // TODO most likely needs id / or same change
       gameDispatch({ type: "exitRoom" })
     }
   }

--- a/src/Components/WaitingRoom.tsx
+++ b/src/Components/WaitingRoom.tsx
@@ -10,6 +10,7 @@ import { deleteDoc } from "firebase/firestore";
 import CloseIcon from '@mui/icons-material/Close';
 import { useRoomHostDocState } from '../Contexts/FirestoreContext';
 import { usePlayerDocState } from '../Contexts/FirestoreContext';
+import { update } from 'lodash';
 
 const WaitingRoom = () => {
   const { gameState, gameDispatch } = useGame();
@@ -67,17 +68,18 @@ const WaitingRoom = () => {
     } else {
       // ! Feel like there could be async issues below but need revision
       // * remove current player from player list 
-      const updatePlayers = players.filter((dbPlayer: any) => dbPlayer.id !== currentPlayer.id)
+      const updatedPlayers = players.filter((dbPlayer: any) => dbPlayer.id !== currentPlayer.id)
+      updatedPlayers.map((player: any, i: number) => player.number = i+1)
       
       // changing host number
       if (currentPlayer.number === host) {
         await setDoc(gameState.roomId, {
-          host: updatePlayers[0].number,
-          players: updatePlayers
+          host: updatedPlayers[0].number,
+          players: updatedPlayers
         })
       } else {
         await setDoc(gameState.roomId, {
-          players: updatePlayers
+          players: updatedPlayers
         })
       }
       gameDispatch({ type: "exitRoom" })

--- a/src/Components/WaitingRoom.tsx
+++ b/src/Components/WaitingRoom.tsx
@@ -10,7 +10,7 @@ import { deleteDoc } from "firebase/firestore";
 import CloseIcon from '@mui/icons-material/Close';
 import { useRoomHostDocState } from '../Contexts/FirestoreContext';
 import { usePlayerDocState } from '../Contexts/FirestoreContext';
-import { update } from 'lodash';
+import { usePlayerDispatch, PlayerFactory, PlayerFactoryType } from '../Contexts/PlayerContext';
 
 const WaitingRoom = () => {
   const { gameState, gameDispatch } = useGame();
@@ -20,10 +20,11 @@ const WaitingRoom = () => {
   const [room] = useDocData(gameState.roomId);
   const { players } = room;
   const host = useRoomHostDocState()
+  const playerDispatch = usePlayerDispatch();
   const { player: currentPlayer } = usePlayerDocState()
 
   useEffect(() => {
-   
+   console.log("current player", currentPlayer)
   }, [host, players])
   
   // Assign actions to existing players ->
@@ -71,6 +72,7 @@ const WaitingRoom = () => {
       const updatedPlayers = players.filter((dbPlayer: any) => dbPlayer.id !== currentPlayer.id)
       updatedPlayers.map((player: any, i: number) => player.number = i+1)
       
+      console.log('updatedPlayers', updatedPlayers)
       // changing host number
       if (currentPlayer.number === host) {
         await setDoc(gameState.roomId, {
@@ -82,6 +84,7 @@ const WaitingRoom = () => {
           players: updatedPlayers
         })
       }
+      playerDispatch({type: "setPlayer", value: undefined});  // TODO most likely needs id / or same change
       gameDispatch({ type: "exitRoom" })
     }
   }
@@ -116,7 +119,7 @@ const WaitingRoom = () => {
                 </Typography>
                 <Button aria-label="close" onClick={handleClose} sx={{padding: "0px"}}><CloseIcon /></Button>
               </Box>
-              { (host === currentPlayer.number) &&
+              { (currentPlayer.number === 1) &&
                 <Stack>
                   <Typography id="modal-modal-description" sx={{ mt: 2 }}>
                   You are about to exit the room. You must reassign the host or end game for all.
@@ -136,7 +139,7 @@ const WaitingRoom = () => {
                   }
                 </Stack>
               }
-              { (host !== currentPlayer.number) &&
+              { (currentPlayer.number !== 1) &&
                 <Stack>
                   <Typography id="modal-modal-description" sx={{ mt: 2 }}>
                   You are about to exit the room. Confirm?
@@ -148,19 +151,19 @@ const WaitingRoom = () => {
             </Box>
           </Modal>    
           }
-          {(host === currentPlayer.number) && 
+          {(currentPlayer.number === 1) && 
             <Stack spacing={2} direction="row" justifyContent="center" style={{margin: "20px 0"}}>
               <Button variant="contained" size="small" disableElevation onClick={startGame}>Start Game</Button>
               <Button variant="contained" size="small" id="back" disableElevation onClick={handleOpen}>Exit Room</Button>          
               <Button variant="contained" size="small" color="error" disableElevation onClick={deleteRoom}>Delete Room</Button>
             </Stack>
           }
-          {(host !== currentPlayer.number) && players.length === 0 && 
+          {(currentPlayer.number !== 1) && players.length === 0 && 
             <Stack spacing={2} direction="row" justifyContent="center" style={{margin: "20px 0", display: "block"}}>
               <Alert severity="info" style={{margin: "20px"}}>This game has been deleted. Please click "back" to return to the Lobby area</Alert>
             </Stack>
           }
-          {(host !== currentPlayer.number) &&
+          {(currentPlayer.number !== 1) &&
             <Stack spacing={2} direction="row" justifyContent="center" style={{margin: "20px 0", display: "block"}}>
               <Box textAlign='center'>
                 <Button variant="contained" size="small" id="back" disableElevation onClick={handleOpen}>Back</Button>

--- a/src/Components/WaitingRoom.tsx
+++ b/src/Components/WaitingRoom.tsx
@@ -19,13 +19,8 @@ const WaitingRoom = () => {
   const handleClose = () => setOpen(false);
   const [room] = useDocData(gameState.roomId);
   const { players } = room;
-  const host = useRoomHostDocState()
   const playerDispatch = usePlayerDispatch();
-  const { player: currentPlayer } = usePlayerDocState()
-
-  useEffect(() => {
-   console.log("current player", currentPlayer)
-  }, [host, players])
+  const { currentPlayer } = usePlayerDocState()
   
   // Assign actions to existing players ->
   // set initial tile ->
@@ -70,13 +65,14 @@ const WaitingRoom = () => {
       // ! Feel like there could be async issues below but need revision
       // * remove current player from player list 
       const updatedPlayers = players.filter((dbPlayer: any) => dbPlayer.id !== currentPlayer.id)
-      updatedPlayers.map((player: any, i: number) => player.number = i+1)
+      // re-assign player numbers
+      updatedPlayers.map((player: any, playerNumber: number) => player.number = playerNumber + 1)
       
-      console.log('updatedPlayers', updatedPlayers)
-      // changing host number
+      // Update players and numbers
       await setDoc(gameState.roomId, {
         players: updatedPlayers
       })
+      // remove player id locally
       playerDispatch({type: "setPlayer", value: null});  // TODO most likely needs id / or same change
       gameDispatch({ type: "exitRoom" })
     }

--- a/src/Components/WaitingRoom.tsx
+++ b/src/Components/WaitingRoom.tsx
@@ -67,7 +67,7 @@ const WaitingRoom = () => {
     } else {
       // ! Feel like there could be async issues below but need revision
       // * remove current player from player list 
-      const updatePlayers = players.filter((dbPlayer: any) => dbPlayer.number !== currentPlayer.number)
+      const updatePlayers = players.filter((dbPlayer: any) => dbPlayer.id !== currentPlayer.id)
       
       // changing host number
       if (currentPlayer.number === host) {

--- a/src/Contexts/FirestoreContext.tsx
+++ b/src/Contexts/FirestoreContext.tsx
@@ -15,9 +15,9 @@ type DBProviderProps = {children: React.ReactNode}
 
 
 const GameStartedDocContext = createContext<any>(undefined);
-const GamePausedDocContext = createContext<any>(undefined);
-const GameOverDocContext = createContext<any>(false);
-const GameWonDocContext = createContext<any>(false);
+const GamePausedDocContext = createContext<boolean>(false);
+const GameOverDocContext = createContext<boolean>(false);
+const GameWonDocContext = createContext<boolean>(false);
 const WeaponsStolenDocContext = createContext<any>(undefined);
 const HeroesEscapedDocContext = createContext<any>(undefined);
 const PlayerHeldPawnDocContext = createContext<DBHeroPawn>({} as DBHeroPawn);
@@ -140,6 +140,7 @@ const useGameWonDocState = () => {
   if (context === undefined) {
     throw new Error('useGameWonDocState must be used within a GameWonDocContext');
   }
+  return context;
 }
 
 const useRoomHostDocState = () => {

--- a/src/Contexts/FirestoreContext.tsx
+++ b/src/Contexts/FirestoreContext.tsx
@@ -28,7 +28,7 @@ const OrangePawnDocContext = createContext<DBHeroPawn>({} as DBHeroPawn);
 const TilesDocContext = createContext<any>(undefined);
 const RoomHostDocContext = createContext<any>(undefined);
 const PlayerDocContext = createContext<{ 
-  players: DBPlayer[], setPlayers: Dispatch<SetStateAction<DBPlayer[]>>,
+  players: DBPlayer[],
   player: DBPlayer, setPlayer: Dispatch<SetStateAction<DBPlayer>> 
 } | undefined>(undefined);
 const PingedDocContext = createContext<boolean>(false);
@@ -44,7 +44,7 @@ const FirestoreProvider = ({children}: DBProviderProps) => {
   const [gamePaused, gameOver, gameWon] = useGamePaused(room);
   const [roomHost] = useRoomHost(room);
   const [tiles] = useTiles(room);
-  const [players, setPlayers, player, setPlayer] = usePlayer();
+  const [players, player, setPlayer] = usePlayer(room);
   const pawns = usePawns(room, gameState.roomId);
   const {green, yellow, purple, orange, playerHeldPawn} = pawns;
 
@@ -72,7 +72,7 @@ const FirestoreProvider = ({children}: DBProviderProps) => {
   }, [room.gameStarted]);
 
   const playerProviderValue = useMemo(() => { // TODO figure out why need useMemo???
-    return {players, setPlayers, player, setPlayer}
+    return {players, player, setPlayer}
   }, [player, players]);
 
   return (

--- a/src/Contexts/FirestoreContext.tsx
+++ b/src/Contexts/FirestoreContext.tsx
@@ -29,7 +29,7 @@ const TilesDocContext = createContext<any>(undefined);
 const RoomHostDocContext = createContext<any>(undefined);
 const PlayerDocContext = createContext<{ 
   players: DBPlayer[],
-  player: DBPlayer, setPlayer: Dispatch<SetStateAction<DBPlayer>> 
+  currentPlayer: DBPlayer
 } | undefined>(undefined);
 const PingedDocContext = createContext<boolean>(false);
 
@@ -44,14 +44,14 @@ const FirestoreProvider = ({children}: DBProviderProps) => {
   const [gamePaused, gameOver, gameWon] = useGamePaused(room);
   const [roomHost] = useRoomHost(room);
   const [tiles] = useTiles(room);
-  const [players, player, setPlayer] = usePlayer(room);
+  const [players, currentPlayer] = usePlayer(room);
   const pawns = usePawns(room, gameState.roomId);
   const {green, yellow, purple, orange, playerHeldPawn} = pawns;
 
   const [pinged, setPinged] = useState(false);
 
   useEffect(() => {
-    if (room.pings.length && room.pings.includes(player.number)) {
+    if (room.pings.length && room.pings.includes(currentPlayer.number)) {
       setPinged(true);
     }
     else {
@@ -72,8 +72,8 @@ const FirestoreProvider = ({children}: DBProviderProps) => {
   }, [room.gameStarted]);
 
   const playerProviderValue = useMemo(() => { // TODO figure out why need useMemo???
-    return {players, player, setPlayer}
-  }, [player, players]);
+    return {players, currentPlayer}
+  }, [currentPlayer, players]);
 
   return (
     <GameStartedDocContext.Provider value={gameStarted}>

--- a/src/Contexts/PlayerContext.tsx
+++ b/src/Contexts/PlayerContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useReducer } from 'react';
 import { heroColor, Player, playerNumber, direction, Escalator, DBPlayer } from '../types';
+import cryptoRandomString from 'crypto-random-string';
 import difference from 'lodash/difference';
 
 const playerNumbers = Array.from({length: 8}, (_, i) => i + 1);
@@ -21,19 +22,20 @@ export interface PlayerFactoryType {
   dbPlayer: DBPlayer
 }
 
-export const PlayerFactory = (playerName: string, currentPlayers: playerNumber[]) => {
-  const newPlayerNumber = difference(playerNumbers, currentPlayers)[0];
+export const PlayerFactory = (playerName: string, playersInLobby: number) => {
+  // const newPlayerNumber = difference(playerNumbers, currentPlayers)[0];
 
   const localPlayerState: Player = {
-    number: newPlayerNumber as playerNumber,
+    number: playersInLobby + 1 as playerNumber,
     // showMovableDirections: [],
     // showTeleportSpaces: null,
     // showEscalatorSpaces: [], // TODO revisit this (trim down data)
   }
 
   const dbPlayerState: DBPlayer = {
+    id: cryptoRandomString({length: 10, type: 'alphanumeric'}),
     name: playerName,
-    number: newPlayerNumber as playerNumber,
+    number: playersInLobby + 1 as playerNumber,
     playerDirections: [], 
     playerAbilities: [],
     // pinged: false

--- a/src/Contexts/PlayerContext.tsx
+++ b/src/Contexts/PlayerContext.tsx
@@ -1,5 +1,8 @@
 import React, { createContext, useContext, useReducer } from 'react';
 import { heroColor, Player, playerNumber, direction, Escalator, DBPlayer } from '../types';
+import difference from 'lodash/difference';
+
+const playerNumbers = Array.from({length: 8}, (_, i) => i + 1);
 
 export type Action = 
   // {type: 'playerHeld', value: number | null, color: heroColor} | 
@@ -18,9 +21,11 @@ export interface PlayerFactoryType {
   dbPlayer: DBPlayer
 }
 
-export const PlayerFactory = (playerName: string, currentPlayers: number) => {
+export const PlayerFactory = (playerName: string, currentPlayers: playerNumber[]) => {
+  const newPlayerNumber = difference(playerNumbers, currentPlayers)[0];
+
   const localPlayerState: Player = {
-    number: currentPlayers + 1 as playerNumber,
+    number: newPlayerNumber as playerNumber,
     // showMovableDirections: [],
     // showTeleportSpaces: null,
     // showEscalatorSpaces: [], // TODO revisit this (trim down data)
@@ -28,7 +33,7 @@ export const PlayerFactory = (playerName: string, currentPlayers: number) => {
 
   const dbPlayerState: DBPlayer = {
     name: playerName,
-    number: currentPlayers + 1 as playerNumber,
+    number: newPlayerNumber as playerNumber,
     playerDirections: [], 
     playerAbilities: [],
     // pinged: false

--- a/src/Contexts/PlayerContext.tsx
+++ b/src/Contexts/PlayerContext.tsx
@@ -10,9 +10,9 @@ export type Action =
   // {type: 'showMovableSpaces', value: direction[]} | 
   // {type: 'showEscalatorSpaces', value: Escalator[]} | 
   // {type: 'showTeleportSpaces', color: heroColor | null} | 
-  {type: 'setPlayer', value: Player | undefined} |
+  {type: 'setPlayer', value: Player | null}
   // {type: 'assignActions', value: Player} | 
-  undefined;
+  | undefined;
 export type Dispatch = (action: Action) => void;
 
 type PlayerProviderProps = {children: React.ReactNode}
@@ -52,11 +52,13 @@ export const PlayerFactory = (playerName: string, playersInLobby: number) => {
 
 const playerInitialState: Player = {} as Player;
 
-const PlayerStateContext = createContext<Player | undefined>(undefined);
+const PlayerStateContext = createContext<Player | null | undefined>(undefined);
 const PlayerDispatchContext = createContext<Dispatch | undefined>(undefined);
 
-const playerReducer = (playerState: Player, action: any) => {
-  let newState = {...playerState};
+type PlayerState = Player | null;
+
+const playerReducer = (playerState: PlayerState, action: any) => {
+  let newState = {...playerState} as PlayerState;
 
   switch (action.type) {
     // case 'playerHeld': {

--- a/src/Contexts/PlayerContext.tsx
+++ b/src/Contexts/PlayerContext.tsx
@@ -10,7 +10,7 @@ export type Action =
   // {type: 'showMovableSpaces', value: direction[]} | 
   // {type: 'showEscalatorSpaces', value: Escalator[]} | 
   // {type: 'showTeleportSpaces', color: heroColor | null} | 
-  {type: 'setPlayer', value: Player} |
+  {type: 'setPlayer', value: Player | undefined} |
   // {type: 'assignActions', value: Player} | 
   undefined;
 export type Dispatch = (action: Action) => void;
@@ -24,16 +24,17 @@ export interface PlayerFactoryType {
 
 export const PlayerFactory = (playerName: string, playersInLobby: number) => {
   // const newPlayerNumber = difference(playerNumbers, currentPlayers)[0];
+  const id = cryptoRandomString({length: 10, type: 'alphanumeric'});
 
   const localPlayerState: Player = {
-    number: playersInLobby + 1 as playerNumber,
+    id,
     // showMovableDirections: [],
     // showTeleportSpaces: null,
     // showEscalatorSpaces: [], // TODO revisit this (trim down data)
   }
 
   const dbPlayerState: DBPlayer = {
-    id: cryptoRandomString({length: 10, type: 'alphanumeric'}),
+    id,
     name: playerName,
     number: playersInLobby + 1 as playerNumber,
     playerDirections: [], 

--- a/src/Contexts/PlayerContext.tsx
+++ b/src/Contexts/PlayerContext.tsx
@@ -1,17 +1,9 @@
 import React, { createContext, useContext, useReducer } from 'react';
 import { heroColor, Player, playerNumber, direction, Escalator, DBPlayer } from '../types';
 import cryptoRandomString from 'crypto-random-string';
-import difference from 'lodash/difference';
-
-const playerNumbers = Array.from({length: 8}, (_, i) => i + 1);
 
 export type Action = 
-  // {type: 'playerHeld', value: number | null, color: heroColor} | 
-  // {type: 'showMovableSpaces', value: direction[]} | 
-  // {type: 'showEscalatorSpaces', value: Escalator[]} | 
-  // {type: 'showTeleportSpaces', color: heroColor | null} | 
   {type: 'setPlayer', value: Player | null}
-  // {type: 'assignActions', value: Player} | 
   | undefined;
 export type Dispatch = (action: Action) => void;
 
@@ -23,14 +15,10 @@ export interface PlayerFactoryType {
 }
 
 export const PlayerFactory = (playerName: string, playersInLobby: number) => {
-  // const newPlayerNumber = difference(playerNumbers, currentPlayers)[0];
   const id = cryptoRandomString({length: 10, type: 'alphanumeric'});
 
   const localPlayerState: Player = {
     id,
-    // showMovableDirections: [],
-    // showTeleportSpaces: null,
-    // showEscalatorSpaces: [], // TODO revisit this (trim down data)
   }
 
   const dbPlayerState: DBPlayer = {
@@ -39,7 +27,6 @@ export const PlayerFactory = (playerName: string, playersInLobby: number) => {
     number: playersInLobby + 1 as playerNumber,
     playerDirections: [], 
     playerAbilities: [],
-    // pinged: false
   }
 
   return {
@@ -48,40 +35,23 @@ export const PlayerFactory = (playerName: string, playersInLobby: number) => {
   }
 }
 
-// assign random number
-
-const playerInitialState: Player = {} as Player;
+const playerInitialState: Player | null = null;
 
 const PlayerStateContext = createContext<Player | null | undefined>(undefined);
 const PlayerDispatchContext = createContext<Dispatch | undefined>(undefined);
 
 type PlayerState = Player | null;
 
-const playerReducer = (playerState: PlayerState, action: any) => {
+const playerReducer = (playerState: PlayerState, action: Action) => {
   let newState = {...playerState} as PlayerState;
 
-  switch (action.type) {
-    // case 'playerHeld': {
-    //   return newState;
-    // }
+  switch (action?.type) {
     case 'setPlayer': { // ONLY THIS used
       newState = action.value;
       return newState;
     }
-    // case 'assignActions': {
-    //   // TODO, these are constant values that never change, should move to a seperate provider,
-    //   // so components using these values do not re-render whenever playerContext value changes.
-    //   // MINOR priority
-    //   // newState.playerAbilities = action.value.playerAbilities;
-    //   // newState.playerDirections = action.value.playerDirections;
-    //   return newState;
-    // }
-    // case 'movePawn': {
-    //   // newState[action.color as keyof Player].position = action.value;
-    //   return newState;
-    // }
     default: {
-      throw new Error(`Unhandled action type: ${action.type}`)
+      throw new Error(`Unhandled action type: ${action?.type}`)
     }
   }
 }

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -38,7 +38,7 @@ export interface Escalator {
 }
 
 export interface Player {
-  number: playerNumber,  // TODO remove, can use values straight from DB
+  id: string,  // TODO remove, can use values straight from DB
 }
 
 
@@ -97,8 +97,8 @@ export interface Room {
 
 
 export interface DBPlayer extends Player {
-  id: string,
   name: string,
+  number: number,
   // pinged: boolean,
   playerDirections: direction[],
   playerAbilities: basicAbility[],

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -97,6 +97,7 @@ export interface Room {
 
 
 export interface DBPlayer extends Player {
+  id: string,
   name: string,
   // pinged: boolean,
   playerDirections: direction[],

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -98,7 +98,7 @@ export interface Room {
 
 export interface DBPlayer extends Player {
   name: string,
-  number: number,
+  number: playerNumber,
   // pinged: boolean,
   playerDirections: direction[],
   playerAbilities: basicAbility[],

--- a/src/utils/usePawns.tsx
+++ b/src/utils/usePawns.tsx
@@ -22,6 +22,7 @@ const usePawns = (room: Room, roomId: string): any => {
   const { green: greenPawn, yellow: yellowPawn, orange: orangePawn, purple: purplePawn } = pawns;
 
   useEffect(() => {
+    setPlayerHeldPawn(() => initPlayerHeldPawn);
     const currentPlayer = room.players.find(player => player.id === playerState?.id)
     if (!currentPlayer) return;
     const currentHeldPawn = Object.values(pawns).find(pawn => pawn.playerHeld === currentPlayer.number);

--- a/src/utils/usePawns.tsx
+++ b/src/utils/usePawns.tsx
@@ -11,7 +11,7 @@ const initPlayerHeldPawn = {
 }
 
 const usePawns = (room: Room, roomId: string): any => {
-  const player = usePlayerState();
+  const playerState = usePlayerState();
   const [playerHeldPawn, setPlayerHeldPawn] = useState<PlayerHeldPawn>(initPlayerHeldPawn);
   const [green, setGreen] = useState<DBHeroPawn>({} as DBHeroPawn);
   const [yellow, setYellow] = useState<DBHeroPawn>({} as DBHeroPawn);
@@ -22,7 +22,9 @@ const usePawns = (room: Room, roomId: string): any => {
   const { green: greenPawn, yellow: yellowPawn, orange: orangePawn, purple: purplePawn } = pawns;
 
   useEffect(() => {
-    const currentHeldPawn = Object.values(pawns).find(pawn => pawn.playerHeld === player.number);
+    const currentPlayer = room.players.find(player => player.id === playerState?.id)
+    if (!currentPlayer) return;
+    const currentHeldPawn = Object.values(pawns).find(pawn => pawn.playerHeld === currentPlayer.number);
     if (!currentHeldPawn) return;
     setPlayerHeldPawn(() => currentHeldPawn || initPlayerHeldPawn);
 

--- a/src/utils/usePlayer.tsx
+++ b/src/utils/usePlayer.tsx
@@ -2,13 +2,13 @@ import { Dispatch, useEffect, SetStateAction, useState } from 'react';
 import { usePlayerState, usePlayerDispatch } from '../Contexts/PlayerContext';
 import { DBPlayer, Room } from '../types';
 
-const usePlayer = (room: Room): [DBPlayer[], DBPlayer, Dispatch<SetStateAction<DBPlayer>>] => {
+const usePlayer = (room: Room): [DBPlayer[], DBPlayer] => {
   // const playerDispatch = usePlayerDispatch();
   const playerState = usePlayerState();
   // Players array should be firestore real time values, only updated by firestore changes
   const [players, setPlayers] = useState<DBPlayer[]>([{} as DBPlayer]);
   // player object should be local
-  const [player, setPlayer] = useState<DBPlayer>({} as DBPlayer);
+  const [currentPlayer, setCurrentPlayer] = useState<DBPlayer>({} as DBPlayer);
 
 
   useEffect(() => {
@@ -20,10 +20,10 @@ const usePlayer = (room: Room): [DBPlayer[], DBPlayer, Dispatch<SetStateAction<D
   useEffect(() => {
     const currentPlayer = players.find(dbPlayer => dbPlayer.id === playerState?.id)
     if (!currentPlayer) return;
-    setPlayer(currentPlayer)
-  }, [players])
+    setCurrentPlayer(currentPlayer)
+  }, [players.length, room.gameStarted])
 
-  return [players, player, setPlayer];
+  return [players, currentPlayer];
 };
 
 export default usePlayer;

--- a/src/utils/usePlayer.tsx
+++ b/src/utils/usePlayer.tsx
@@ -1,11 +1,29 @@
 import { Dispatch, useEffect, SetStateAction, useState } from 'react';
+import { usePlayerState, usePlayerDispatch } from '../Contexts/PlayerContext';
 import { DBPlayer, Room } from '../types';
 
-const usePlayer = (): [DBPlayer[], Dispatch<SetStateAction<DBPlayer[]>>, DBPlayer, Dispatch<SetStateAction<DBPlayer>>] => {
+const usePlayer = (room: Room): [DBPlayer[], DBPlayer, Dispatch<SetStateAction<DBPlayer>>] => {
+  // const playerDispatch = usePlayerDispatch();
+  const playerState = usePlayerState();
+  // Players array should be firestore real time values, only updated by firestore changes
   const [players, setPlayers] = useState<DBPlayer[]>([{} as DBPlayer]);
+  // player object should be local
   const [player, setPlayer] = useState<DBPlayer>({} as DBPlayer);
 
-  return [players, setPlayers, player, setPlayer];
+
+  useEffect(() => {
+    // TODO not working correctly
+    console.log('room players update useEffect', room.players)
+    setPlayers(room.players);
+  }, [room.players])
+
+  useEffect(() => {
+    const currentPlayer = players.find(dbPlayer => dbPlayer.id === playerState.id)
+    if (!currentPlayer) return;
+    setPlayer(currentPlayer)
+  }, [players])
+
+  return [players, player, setPlayer];
 };
 
 export default usePlayer;

--- a/src/utils/usePlayer.tsx
+++ b/src/utils/usePlayer.tsx
@@ -18,7 +18,7 @@ const usePlayer = (room: Room): [DBPlayer[], DBPlayer, Dispatch<SetStateAction<D
   }, [room.players])
 
   useEffect(() => {
-    const currentPlayer = players.find(dbPlayer => dbPlayer.id === playerState.id)
+    const currentPlayer = players.find(dbPlayer => dbPlayer.id === playerState?.id)
     if (!currentPlayer) return;
     setPlayer(currentPlayer)
   }, [players])

--- a/src/utils/usePlayer.tsx
+++ b/src/utils/usePlayer.tsx
@@ -21,7 +21,7 @@ const usePlayer = (room: Room): [DBPlayer[], DBPlayer] => {
     const currentPlayer = players.find(dbPlayer => dbPlayer.id === playerState?.id)
     if (!currentPlayer) return;
     setCurrentPlayer(currentPlayer)
-  }, [players.length, room.gameStarted])
+  }, [players])
 
   return [players, currentPlayer];
 };


### PR DESCRIPTION
There is currently a bug. Where if a player leaves lobby its player number will not get reassigned to new players joining the room. Which can end up with player number going past the restricted numbers being 1-8.
<img width="323" alt="Screen Shot 2023-03-01 at 10 57 21 am" src="https://user-images.githubusercontent.com/51236363/222289032-53592da4-86a5-42ae-85ca-981b0582fcc2.png">

